### PR TITLE
Add sample Three.js maze shooter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,31 @@
-# maze-tap-shooter
+# Maze Tap Shooter
+
+A simple Three.js experiment where you shoot the walls of a randomly generated maze.
+
+## Installation
+
+Clone this repository:
+
+```bash
+git clone <repo-url>
+cd maze-tap-shooter
+```
+
+No additional dependencies are required because the game loads Three.js from a CDN.
+
+## Running Locally
+
+Serve the files using a local web server so that the scripts load correctly:
+
+```bash
+python -m http.server
+```
+
+Then open `http://localhost:8000/` in your browser. The game should start automatically.
+
+## Project Structure
+
+- `index.html` – main HTML page.
+- `style.css` – HUD layout and basic styling.
+- `maze.js` – maze generation logic.
+- `main.js` – game setup and interactions using Three.js.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Maze Tap Shooter</title>
+  <link rel="stylesheet" href="style.css">
+</head>
+<body>
+  <div id="hud">
+    <span id="score">Score: 0</span>
+    <span id="health">Health: 100</span>
+  </div>
+  <div id="game-container"></div>
+  <script src="https://cdn.jsdelivr.net/npm/three@0.152.0/build/three.min.js"></script>
+  <script src="maze.js"></script>
+  <script src="main.js"></script>
+</body>
+</html>

--- a/main.js
+++ b/main.js
@@ -1,0 +1,60 @@
+(function(){
+  const container = document.getElementById('game-container');
+  const hudScore = document.getElementById('score');
+  let score = 0;
+
+  const scene = new THREE.Scene();
+  const camera = new THREE.PerspectiveCamera(75, window.innerWidth / window.innerHeight, 0.1, 1000);
+  const renderer = new THREE.WebGLRenderer();
+  renderer.setSize(window.innerWidth, window.innerHeight);
+  container.appendChild(renderer.domElement);
+
+  const maze = new Maze(10, 10);
+  const walls = maze.buildMeshes();
+  walls.forEach(w => scene.add(w));
+
+  const planeGeometry = new THREE.PlaneGeometry(10, 10);
+  const planeMaterial = new THREE.MeshBasicMaterial({ color: 0x222222 });
+  const plane = new THREE.Mesh(planeGeometry, planeMaterial);
+  plane.rotation.x = -Math.PI / 2;
+  plane.position.set(4.5, 0, 4.5);
+  scene.add(plane);
+
+  camera.position.set(5, 10, 15);
+  camera.lookAt(5, 0, 5);
+
+  const raycaster = new THREE.Raycaster();
+  const mouse = new THREE.Vector2();
+
+  function onClick(event) {
+    mouse.x = (event.clientX / renderer.domElement.clientWidth) * 2 - 1;
+    mouse.y = -(event.clientY / renderer.domElement.clientHeight) * 2 + 1;
+    raycaster.setFromCamera(mouse, camera);
+    const intersects = raycaster.intersectObjects(walls);
+    if (intersects.length > 0) {
+      const hit = intersects[0].object;
+      scene.remove(hit);
+      const index = walls.indexOf(hit);
+      if (index !== -1) walls.splice(index, 1);
+      score += 1;
+      hudScore.textContent = 'Score: ' + score;
+    }
+  }
+
+  renderer.domElement.addEventListener('click', onClick);
+
+  window.addEventListener('resize', () => {
+    const width = window.innerWidth;
+    const height = window.innerHeight;
+    renderer.setSize(width, height);
+    camera.aspect = width / height;
+    camera.updateProjectionMatrix();
+  });
+
+  function animate() {
+    requestAnimationFrame(animate);
+    renderer.render(scene, camera);
+  }
+
+  animate();
+})();

--- a/maze.js
+++ b/maze.js
@@ -1,0 +1,43 @@
+(function(global){
+  function Maze(width, height) {
+    this.width = width;
+    this.height = height;
+    this.grid = [];
+    for (let y = 0; y < height; y++) {
+      this.grid[y] = [];
+      for (let x = 0; x < width; x++) {
+        // 1 means wall, 0 means empty
+        this.grid[y][x] = 1;
+      }
+    }
+    this.generate();
+  }
+
+  Maze.prototype.generate = function() {
+    for (let y = 1; y < this.height - 1; y++) {
+      for (let x = 1; x < this.width - 1; x++) {
+        if (Math.random() > 0.3) {
+          this.grid[y][x] = 0;
+        }
+      }
+    }
+  };
+
+  Maze.prototype.buildMeshes = function() {
+    const walls = [];
+    const geometry = new THREE.BoxGeometry(1, 1, 1);
+    for (let y = 0; y < this.height; y++) {
+      for (let x = 0; x < this.width; x++) {
+        if (this.grid[y][x] === 1) {
+          const material = new THREE.MeshBasicMaterial({ color: 0x808080 });
+          const mesh = new THREE.Mesh(geometry, material);
+          mesh.position.set(x, 0.5, y);
+          walls.push(mesh);
+        }
+      }
+    }
+    return walls;
+  };
+
+  global.Maze = Maze;
+})(this);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,26 @@
+body {
+  margin: 0;
+  overflow: hidden;
+  font-family: Arial, sans-serif;
+  background: #000;
+  color: #fff;
+}
+
+#game-container {
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+}
+
+#hud {
+  position: absolute;
+  top: 10px;
+  left: 10px;
+  z-index: 10;
+}
+
+#hud span {
+  margin-right: 15px;
+}


### PR DESCRIPTION
## Summary
- add basic index.html scaffolding and link scripts
- create style.css for HUD layout
- implement simple maze generation in `maze.js`
- add Three.js scene with click-to-remove walls in `main.js`
- rewrite README with install and local run instructions

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6853afa385cc832cb98928eac43e65e7