### PR TITLE
Add cockpit wireframe

### DIFF
--- a/index.html
+++ b/index.html
@@ -417,7 +417,7 @@
     window.addEventListener('orientationchange', handleOrientation);
   });
 
-  function createTarget(isEnemy, powerupType = 'reload_pack') { 
+  function createTarget(isEnemy, powerupType = 'reload_pack') {
       if (!scene || !textureLoader) { 
           console.error("[createTarget] ERROR: scene or textureLoader not initialized!");
           return null;
@@ -541,6 +541,27 @@
       }
   }
 
+  function createCockpit() {
+    const group = new THREE.Group();
+    const material = new THREE.LineBasicMaterial({
+      color: 0x00ffcc,
+      opacity: 0.6,
+      transparent: true
+    });
+    const vertices = new Float32Array([
+      -1.2, -0.4, -1.2,  1.2, -0.4, -1.2,
+       1.2, -0.4, -1.2,  0.8,  0.5, -0.7,
+       0.8,  0.5, -0.7, -0.8,  0.5, -0.7,
+      -0.8,  0.5, -0.7, -1.2, -0.4, -1.2
+    ]);
+    const geometry = new THREE.BufferGeometry();
+    geometry.setAttribute('position', new THREE.BufferAttribute(vertices, 3));
+    const frame = new THREE.LineSegments(geometry, material);
+    group.add(frame);
+    group.position.set(0, 0, -0.6);
+    return group;
+  }
+
 
   function initGame(){
     console.log("[DEBUG] initGame started.");
@@ -635,9 +656,10 @@
     d1.position.set(5,10,5); scene.add(d1);
     
     const muzzleFlash = new THREE.PointLight(0xffff00, 0, 10);
-    muzzleFlash.position.set(0,0,-0.5); 
+    muzzleFlash.position.set(0,0,-0.5);
     camera.add(muzzleFlash);
-    if (!camera.parent) scene.add(camera); 
+    camera.add(createCockpit());
+    if (!camera.parent) scene.add(camera);
 
     const grid = new THREE.GridHelper(300,60,0x00ff88,0x224444);
     scene.add(grid);


### PR DESCRIPTION
## Summary
- implement `createCockpit()` to build a simple wireframe cockpit
- attach the cockpit group to the camera so it moves with the player

## Testing
- `python3 -m http.server` *(fails: no requests made)*

------
https://chatgpt.com/codex/tasks/task_e_685b1a8b72f0832c824082dcd41398b6